### PR TITLE
Make tubelib upgrade behaviour compatible with the battery/fuel slot, and the empty/full batteries

### DIFF
--- a/terumet/interop/tubelib.lua
+++ b/terumet/interop/tubelib.lua
@@ -3,6 +3,8 @@ if tubelib.version < 2.0 then
     tube = 'tubelib:tube1'
 end
 
+local base_mach = terumet.machine
+
 terumet.register_machine_upgrade('tubelib', 'Tube Support Upgrade', 'Allows machine to interface with tubelib tubes', 'Any machine with input/output', {tube})
 
 local machine_check = function(machine, player_name)
@@ -10,11 +12,46 @@ local machine_check = function(machine, player_name)
     ---terumet.machine.has_auth(machine, player_name)
 end
 
+function push_item(machine, item, dir)
+    if 
+        machine.class.fsdef.battery_slot
+        and (
+            (
+                dir == 'in'
+                and item:get_definition().groups._terumetal_battery == 1
+            )
+            or (
+                dir == 'out'
+                and item:get_definition().groups._terumetal_battery == 2
+            )
+        ) then
+        return tubelib.put_item(machine.meta, 'battery', item)
+    end
+    if 
+        machine.class.fsdef.fuel_slot
+        and (
+            (
+                dir == 'in'
+                and item:get_definition().groups._terumetal_battery == 2
+            )
+            or (
+                dir == 'out'
+                and item:get_definition().groups._terumetal_battery == 1
+            )
+        ) then
+        return tubelib.put_item(machine.meta, 'fuel', item)
+    end
+    if dir == 'in' and base_mach.has_ext_input(machine) then
+        return false
+    end
+    return tubelib.put_item(machine.meta, dir, item)
+end
+
 local PUSH_FUNC = function (dir)
     return function(pos, side, item, player_name)
         local machine = terumet.machine.readonly_state(pos)
         if machine_check(machine) then
-            local result = tubelib.put_item(machine.meta, dir, item)
+            local result = push_item(machine, item, dir)
             if result then machine.class.on_inventory_change(machine) end
             return result
         end
@@ -26,7 +63,34 @@ local TUBELIB_MACHINE_DEF = {
     on_pull_item = function(pos, side, player_name)
         local machine = terumet.machine.readonly_state(pos)
         if machine_check(machine) then
-            return tubelib.get_item(machine.meta, 'out')
+            if machine.class.fsdef.battery_slot then
+                local battery_item = tubelib.get_item(machine.meta, 'battery')
+                if battery_item and not battery_item:is_empty() then
+                    local battery_item_definition = battery_item:get_definition()
+                    if battery_item_definition.groups._terumetal_battery == 2 then
+                        return battery_item
+                    else
+                        machine.inv:set_stack('battery', 1, battery_item)
+                    end
+                end
+            end
+            if machine.class.fsdef.fuel_slot then
+                local battery_item = tubelib.get_item(machine.meta, 'fuel')
+                if battery_item and not battery_item:is_empty() then
+                    local battery_item_definition = battery_item:get_definition()
+                    if battery_item_definition.groups._terumetal_battery == 1 then
+                        return battery_item
+                    else
+                        machine.inv:set_stack('fuel', 1, battery_item)
+                    end
+                end
+            end
+            if not base_mach.has_ext_output(machine) then
+                local output_item = tubelib.get_item(machine.meta, 'out')
+                if output_item and not output_item:is_empty() then
+                    return output_item
+                end
+            end
         end
         return nil
     end,
@@ -46,9 +110,13 @@ tubelib.register_node(terumet.id('mach_asmelt'), {terumet.id('mach_asmelt_lit')}
 tubelib.register_node(terumet.id('mach_htfurn'), {terumet.id('mach_htfurn_lit')}, TUBELIB_MACHINE_DEF)
 tubelib.register_node(terumet.id('mach_lavam'), {terumet.id('mach_lavam_lit')}, TUBELIB_MACHINE_DEF)
 tubelib.register_node(terumet.id('mach_htr_furnace'), {terumet.id('mach_htr_furnace_lit')}, TUBELIB_MACHINE_DEF)
+tubelib.register_node(terumet.id('mach_htr_solar'), terumet.EMPTY, TUBELIB_MACHINE_DEF)
+tubelib.register_node(terumet.id('mach_htr_entropy'), terumet.EMPTY, TUBELIB_MACHINE_DEF)
 tubelib.register_node(terumet.id('mach_crusher'), {terumet.id('mach_crusher_lit')}, TUBELIB_MACHINE_DEF)
 --oops: mese garden has no upgrade slots... consider adding it if support for other upgrades is added in future
 --tubelib.register_node(terumet.id('mach_meseg'), terumet.EMPTY, TUBELIB_MACHINE_DEF)
 tubelib.register_node(terumet.id('mach_repm'), terumet.EMPTY, TUBELIB_MACHINE_DEF)
 tubelib.register_node(terumet.id('mach_vulcan'), terumet.EMPTY, TUBELIB_MACHINE_DEF)
 tubelib.register_node(terumet.id('mach_vcoven'), terumet.EMPTY, TUBELIB_MACHINE_DEF)
+tubelib.register_node(terumet.id('mach_thermobox'), terumet.EMPTY, TUBELIB_MACHINE_DEF)
+tubelib.register_node(terumet.id('mach_thermdist'), terumet.EMPTY, TUBELIB_MACHINE_DEF)

--- a/terumet/machine/heater/entropic_htr.lua
+++ b/terumet/machine/heater/entropic_htr.lua
@@ -181,7 +181,7 @@ ent_htr.nodedef = base_mach.nodedef{
     -- terumet machine class data
     _terumach_class = {
         name = 'Environmental Entropy Extraction Heater',
-        valid_upgrades = terumet.valid_upgrade_sets{'heater'},
+        valid_upgrades = terumet.valid_upgrade_sets{'heater','tubelib'},
         timer = 0.5,
         fsdef = FSDEF,
         default_heat_xfer = base_mach.HEAT_XFER_MODE.PROVIDE_ONLY,

--- a/terumet/machine/heater/solar_htr.lua
+++ b/terumet/machine/heater/solar_htr.lua
@@ -114,7 +114,7 @@ sol_htr.nodedef = base_mach.nodedef{
     -- terumet machine class data
     _terumach_class = {
         name = 'Solar Heater',
-        valid_upgrades = terumet.valid_upgrade_sets{'heater'},
+        valid_upgrades = terumet.valid_upgrade_sets{'heater','tubelib'},
         timer = 1.0,
         -- heatlines cannot send heat to this machine
         heatline_target = false,

--- a/terumet/machine/transfer/thermdist.lua
+++ b/terumet/machine/transfer/thermdist.lua
@@ -25,7 +25,7 @@ function base_tdist.init(pos)
     inv:set_size('fuel', 1)
     inv:set_size('battery', 1)
     inv:set_size('out', 1)
-    inv:set_size('upgrade', 2)
+    inv:set_size('upgrade', 3)
     local init_box = {
         class = base_tdist.nodedef._terumach_class,
         state = base_tdist.STATE.IDLE,
@@ -102,7 +102,7 @@ base_tdist.nodedef = base_mach.nodedef{
     -- terumet machine class data
     _terumach_class = {
         name = 'Thermal Distributor',
-        valid_upgrades = terumet.valid_upgrade_sets(),
+        valid_upgrades = terumet.valid_upgrade_sets{'tubelib'},
         timer = 1.0,
         fsdef = FSDEF,
         default_heat_xfer = base_mach.HEAT_XFER_MODE.ACCEPT,

--- a/terumet/machine/transfer/thermobox.lua
+++ b/terumet/machine/transfer/thermobox.lua
@@ -23,7 +23,7 @@ local FSDEF = {
 function base_tbox.init(pos)
     local meta = minetest.get_meta(pos)
     local inv = meta:get_inventory()
-    inv:set_size('upgrade', 2)
+    inv:set_size('upgrade', 3)
     inv:set_size('fuel', 1)
     inv:set_size('battery', 1)
     local init_box = {
@@ -106,7 +106,7 @@ base_tbox.nodedef = base_mach.nodedef{
     -- terumet machine class data
     _terumach_class = {
         name = 'Thermobox',
-        valid_upgrades = terumet.valid_upgrade_sets(),
+        valid_upgrades = terumet.valid_upgrade_sets{'tubelib'},
         timer = 1.0,
         fsdef = FSDEF,
         default_heat_xfer = base_mach.HEAT_XFER_MODE.ACCEPT,

--- a/terumet/material/upgrade.lua
+++ b/terumet/material/upgrade.lua
@@ -68,6 +68,7 @@ terumet.register_machine_upgrade('cheat', 'Infinite Heat Upgrade', 'Testing or c
 local SETS = {
     ALL={cheat=1, max_heat=1, heat_xfer=1, speed_up=1},
     heater={gen_up=1},
+    tubelib={tubelib=1},
     input={ext_input=1, ext_both=1, tubelib=1},
     output={ext_output=1, ext_both=1, tubelib=1},
     crystal={cryst=1, tmcrys=1},


### PR DESCRIPTION
In addition to the core changes, this also:

- Adds an extra upgrade slot to thermal distributors and thermoboxes
- Makes the solar heater, entropic heater, thermal distributor and thermobox tubelib compatible
- Makes using the tubelib upgrade functionality disabled for machines with external input/output upgrades respectively

Make sure batteries can be input and output using the following rules:

- An empty battery can be put into a battery slot
- A full battery can be removed from a battery slot
- A full battery can be put into a fuel slot
- An empty battery can be removed from a fuel slot
- If a full battery cannot be removed from a battery slot, put it back
- If an empty battery cannot be removed from a fuel slot, put it back